### PR TITLE
Fix branch names for some GitHub Workflows

### DIFF
--- a/.github/workflows/draft-release.yaml
+++ b/.github/workflows/draft-release.yaml
@@ -4,7 +4,7 @@ name: Draft Release
 on:
   push:
     branches:
-      - master
+      - main
 
 permissions:
   contents: read

--- a/.github/workflows/terraform-tests.yaml
+++ b/.github/workflows/terraform-tests.yaml
@@ -6,7 +6,7 @@ on:
     inputs:
       # workflow-branch is used to choose the correct workflow repository branch
       workflow-branch:
-        default: master
+        default: main
         type: string
         required: false
       # enable-aws will allow the configure-aws-credentials GitHub Action to run


### PR DESCRIPTION
Fix the branch name from `master` to `main` for some GitHub Workflows as these were set to `master` in error.

## Checklist

Please confirm the following checks:

- [x] My pull request follows the guidelines set out in `CONTRIBUTING.md`.
- [ ] I have performed a self-review of my code and run any tests locally to check.
- [ ] I have added tests that prove my changes are effective and work correctly.
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my code and corrected any misspellings.
- [x] Each commit in this pull request has a meaningful subject & body for context.
- [x] I have squashed all "fix(up)" commits to provide a clean code history.
- [x] My pull request has an appropriate title and description for context.
- [ ] I have linked this pull request to other issues or pull requests as needed.
- [x] I have added `type/...`, `changes/...`, and 'release/...' labels as needed.
