### PR TITLE
Migrate tfsec to trivy as tfsec is joining Trivy

### DIFF
--- a/.github/workflows/terraform-checks.yaml
+++ b/.github/workflows/terraform-checks.yaml
@@ -188,16 +188,18 @@ jobs:
           git-push: true
           git-commit-message: Syncing terraform-docs update for ${{ inputs.working-directory }}/README.md
 
-      - name: Run tfsec against the ${{ inputs.type }}
-        uses: aquasecurity/tfsec-action@v1.0.3
+      - name: Run trivy against the ${{ inputs.type }}
+        uses: aquasecurity/trivy-action@v0.14
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          working_directory: ${{ inputs.working-directory }}
-          format: lovely,sarif
-          additional_args: --out=tfsec
+          github-pat: ${{ secrets.GITHUB_TOKEN }}
+          trivy-config: .trivy.yaml
+          scan-type: fs
+          scan-ref: ${{ inputs.working-directory }}
+          format: sarif
+          output: trivy-results.sarif
 
-      - name: Upload the tfsec SARIF file for the ${{ inputs.type }}
+      - name: Upload the trivy SARIF file for the ${{ inputs.type }}
         uses: github/codeql-action/upload-sarif@v2
         with:
-          sarif_file: ${{ inputs.working-directory }}/tfsec.sarif.json
-          category: tfsec-${{ inputs.type }}
+          sarif_file: ${{ inputs.working-directory }}/trivy-results.sarif
+          category: trivy-${{ inputs.type }}


### PR DESCRIPTION
Following the notice that `tfsec` is joining Trivy, update the `terraform-checks` workflow to use `trivy` instead of `tfsec.`

## Checklist

Please confirm the following checks:

- [x] My pull request follows the guidelines set out in `CONTRIBUTING.md`.
- [ ] I have performed a self-review of my code and run any tests locally to check.
- [ ] I have added tests that prove my changes are effective and work correctly.
- [x] I have made corresponding changes to the documentation as needed.
- [x] I have checked my code and corrected any misspellings.
- [x] Each commit in this pull request has a meaningful subject & body for context.
- [x] I have squashed all "fix(up)" commits to provide a clean code history.
- [x] My pull request has an appropriate title and description for context.
- [ ] I have linked this pull request to other issues or pull requests as needed.
- [x] I have added `type/...`, `changes/...`, and 'release/...' labels as needed.
