### PR TITLE
Use branch name instead of version for `trivy-action`

### DIFF
--- a/.github/workflows/terraform-checks.yaml
+++ b/.github/workflows/terraform-checks.yaml
@@ -189,7 +189,7 @@ jobs:
           git-commit-message: Syncing terraform-docs update for ${{ inputs.working-directory }}/README.md
 
       - name: Run trivy against the ${{ inputs.type }}
-        uses: aquasecurity/trivy-action@v0.14.0
+        uses: aquasecurity/trivy-action@master
         with:
           github-pat: ${{ secrets.GITHUB_TOKEN }}
           trivy-config: .trivy.yaml


### PR DESCRIPTION
Use the branch name instead of the version of the `trivy-action` action based on their documentation, as GitHub Actions is reporting that it is unable to find `v0.14.0`.

## Checklist

Please confirm the following checks:

- [x] My pull request follows the guidelines set out in `CONTRIBUTING.md`.
- [ ] I have performed a self-review of my code and run any tests locally to check.
- [ ] I have added tests that prove my changes are effective and work correctly.
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my code and corrected any misspellings.
- [x] Each commit in this pull request has a meaningful subject & body for context.
- [x] I have squashed all "fix(up)" commits to provide a clean code history.
- [x] My pull request has an appropriate title and description for context.
- [ ] I have linked this pull request to other issues or pull requests as needed.
- [x] I have added `type/...`, `changes/...`, and 'release/...' labels as needed.
