### PR TITLE
Update `terraform-docs` settings and checkout `ref`

### DIFF
--- a/.github/workflows/terraform-checks.yaml
+++ b/.github/workflows/terraform-checks.yaml
@@ -40,6 +40,8 @@ jobs:
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
 
       - name: Checkout the workflows-reusable-terraform repository
         uses: actions/checkout@v4
@@ -181,8 +183,13 @@ jobs:
         with:
           working-dir: ${{ inputs.working-directory }}
           # This needs to point to the location inside the container, not inside
-          # the repository, or on the agent
+          # the repository, or on the agent, so override it here
           config-file: /github/workspace/.terraform-docs.yaml
+          # This Action overrides a number of settings used in the configuration
+          # file with default versions via the command line arguments, so set
+          # these to be empty to use the .terraform-docs.yaml file instead
+          output-method: ""
+          template: ""
           git-push: true
           git-commit-message: Syncing terraform-docs update for ${{ inputs.working-directory }}/README.md
 


### PR DESCRIPTION
Update the default settings for `terraform-docs`, emptying the settings for `output-method` and `template`, otherwise these are overridden on the command-line by the Action and the `.terraform-docs.yaml` configuration file provided is ignored.

Also, update the checkout Action with the reference for the checkout so that the `git-push` for `terraform-docs` will work again.

## Checklist

Please confirm the following checks:

- [x] My pull request follows the guidelines set out in `CONTRIBUTING.md`.
- [ ] I have performed a self-review of my code and run any tests locally to check.
- [ ] I have added tests that prove my changes are effective and work correctly.
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my code and corrected any misspellings.
- [x] Each commit in this pull request has a meaningful subject & body for context.
- [x] I have squashed all "fix(up)" commits to provide a clean code history.
- [x] My pull request has an appropriate title and description for context.
- [ ] I have linked this pull request to other issues or pull requests as needed.
- [x] I have added `type/...`, `changes/...`, and 'release/...' labels as needed.
